### PR TITLE
[KW24D] add support for kw24d in mcr20a driver

### DIFF
--- a/source/MCR20Drv.c
+++ b/source/MCR20Drv.c
@@ -111,7 +111,9 @@ void
     xcvr_spi_configure_speed(gXcvrSpiInstance_c, 8000000);
 
     gXcvrDeassertCS_d();
-    MCR20Drv_RST_B_Deassert();
+    #if !defined(TARGET_KW24D)
+      MCR20Drv_RST_B_Deassert();
+    #endif
     RF_IRQ_Init();
     RF_IRQ_Disable();
     mPhyIrqDisableCnt = 1;
@@ -643,6 +645,7 @@ void MCR20Drv_RESET
 void
 )
 {
+  #if !defined(TARGET_KW24D)
     volatile uint32_t delay = 1000;
     //assert RST_B
     MCR20Drv_RST_B_Assert();
@@ -651,6 +654,7 @@ void
 
     //deassert RST_B
     MCR20Drv_RST_B_Deassert();
+  #endif
 }
 
 /*---------------------------------------------------------------------------

--- a/source/NanostackRfPhyMcr20a.cpp
+++ b/source/NanostackRfPhyMcr20a.cpp
@@ -1714,7 +1714,7 @@ static void rf_if_unlock(void)
 
 NanostackRfPhyMcr20a::NanostackRfPhyMcr20a(PinName spi_mosi, PinName spi_miso,
         PinName spi_sclk, PinName spi_cs,  PinName spi_rst, PinName spi_irq)
-    : _spi(spi_mosi, spi_miso, spi_sclk), _rf_cs(spi_cs), _rf_rst(spi_rst),
+    : _spi(spi_mosi, spi_miso, spi_sclk), _rf_cs(spi_cs), _rf_rst(spi_rst, 1),
       _rf_irq(spi_irq), _rf_irq_pin(spi_irq)
 {
     // Do nothing

--- a/source/NanostackRfPhyMcr20a.cpp
+++ b/source/NanostackRfPhyMcr20a.cpp
@@ -53,8 +53,11 @@ extern "C" {
 #define gCcaCCA_MODE1_c        1
 
 #define gXcvrRunState_d       gXcvrPwrAutodoze_c
-#define gXcvrLowPowerState_d  gXcvrPwrHibernate_c
-
+#if !defined(TARGET_KW24D)
+  #define gXcvrLowPowerState_d  gXcvrPwrHibernate_c
+#else 
+  #define gXcvrLowPowerState_d  gXcvrPwrAutodoze_c
+#endif
 
 /* MCR20A XCVR states */
 typedef enum xcvrState_tag{
@@ -495,7 +498,9 @@ static void rf_init(void)
     /* Disable Tristate on MISO for SPI reads */
     MCR20Drv_IndirectAccessSPIWrite(MISC_PAD_CTRL, 0x02);
     /* Set XCVR clock output settings */
-    MCR20Drv_Set_CLK_OUT_Freq(gMCR20_ClkOutFreq_d);
+    #if !defined(TARGET_KW24D)
+      MCR20Drv_Set_CLK_OUT_Freq(gMCR20_ClkOutFreq_d);
+    #endif
     /* Set default XCVR power state */
     rf_set_power_state(gXcvrRunState_d);
 


### PR DESCRIPTION
This pull request adds support for KW24D in the MCR20A driver.  The KW24D uses the MCR20A internally, but it has special considerations verses the stand-alone MCR20A shield.  

When TARGET_KW24D is defined, avoid calls to MCR20A reset and low power mode entry to avoid disruption of the internal cock out from the MCR20A which supplies the MCU inside KW24D.  

This has been tested with mbed-os-example-mesh minimal and successfully connects.  

A patch is required to mbed-os for a couple small KW24D updates.  This will be coming very soon.  

cc @mmahadevan108 