### PR TITLE
Port to CMSIS5/RTX2

### DIFF
--- a/source/MCR20Reg.h
+++ b/source/MCR20Reg.h
@@ -343,7 +343,7 @@ typedef union regIRQSTS2_tag{
     uint8_t PB_ERR_IRQ:1;
     uint8_t ASM_IRQ:1;
     uint8_t TMRSTATUS:1;
-    uint8_t PI:1;
+    uint8_t PI_:1;
     uint8_t SRCADDR:1;
     uint8_t CCA:1;
     uint8_t CRCVALID:1;

--- a/source/NanostackRfPhyMcr20a.cpp
+++ b/source/NanostackRfPhyMcr20a.cpp
@@ -1102,8 +1102,8 @@ static void PHY_InterruptHandler(void)
 static void PHY_InterruptThread(void)
 {
     for (;;) {
-        osEvent event = irq_thread.signal_wait(0);
-        if (event.status != osEventSignal) {
+        uint32_t signal = irq_thread.signal_wait(0);
+        if (signal & osFlagsError) {
             continue;
         }
         handle_interrupt();


### PR DESCRIPTION
I had to change the register name to `PI_` as `PI` clashes with cmsis math header (it has to be included for compatibility reasons for IAR builds).

@SeppoTakalo @kjbracey-arm Same as https://github.com/ARMmbed/atmel-rf-driver/pull/51