### PR TITLE
Rename PI register to PI_ to avoid name clash with math PI

### DIFF
--- a/source/MCR20Reg.h
+++ b/source/MCR20Reg.h
@@ -343,7 +343,7 @@ typedef union regIRQSTS2_tag{
     uint8_t PB_ERR_IRQ:1;
     uint8_t ASM_IRQ:1;
     uint8_t TMRSTATUS:1;
-    uint8_t PI:1;
+    uint8_t PI_:1;
     uint8_t SRCADDR:1;
     uint8_t CCA:1;
     uint8_t CRCVALID:1;


### PR DESCRIPTION
We need to include arm_math.h from CMSIS to get a CLZ implementation for
IAR compiler, unfortunetely this header defined PI as a macro which
colides with MCR register.

Needed for: https://github.com/ARMmbed/mbed-os/pull/4294