### PR TITLE
Eliminate static data when unreferenced

### DIFF
--- a/mcr20a-rf-driver/NanostackRfPhyMcr20a.h
+++ b/mcr20a-rf-driver/NanostackRfPhyMcr20a.h
@@ -60,6 +60,7 @@ private:
     DigitalOut _rf_rst;
     InterruptIn _rf_irq;
     DigitalIn _rf_irq_pin;
+    Thread _irq_thread;
 
     void _pins_set();
     void _pins_clear();


### PR DESCRIPTION
Avoid static ROM + RAM use when driver is not referenced.

Saves about 100 bytes of ROM and 200 bytes of RAM in mbed OS
easy-connect when using a different driver.