### PR TITLE
Allow driver to provide default NanostackRfPhy

### DIFF
--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -1,0 +1,9 @@
+{
+    "name": "mcr20a",
+    "config": {
+        "provide-default": {
+            "help": "Provide default NanostackRfpy. [true/false]",
+            "value": false
+        }
+    }
+}

--- a/source/NanostackRfPhyMcr20a.cpp
+++ b/source/NanostackRfPhyMcr20a.cpp
@@ -1818,4 +1818,14 @@ void NanostackRfPhyMcr20a::_pins_clear()
     irq_thread = NULL;
 }
 
+#if MBED_CONF_MCR20A_PROVIDE_DEFAULT || DEVICE_MCR20A
+
+NanostackRfPhy &NanostackRfPhy::get_default_instance()
+{
+    static NanostackRfPhyMcr20a rf_phy(MCR20A_SPI_MOSI, MCR20A_SPI_MISO, MCR20A_SPI_SCLK, MCR20A_SPI_CS, MCR20A_SPI_RST, MCR20A_SPI_IRQ);
+    return rf_phy;
+}
+
+#endif // MBED_CONF_MCR20A_PROVIDE_DEFAULT
+
 #endif // MBED_CONF_NANOSTACK_CONFIGURATION


### PR DESCRIPTION
Devices like KW24D can also specify "DEVICE_MCR20A" flag to enable
this driver as a default for Mesh interfaces.