### PR TITLE
disable and enable interrupts in interrupt thread

### DIFF
--- a/source/MCR20Drv.c
+++ b/source/MCR20Drv.c
@@ -44,7 +44,7 @@
 
 #ifdef MBED_CONF_NANOSTACK_CONFIGURATION
 
-#include "platform/arm_hal_interrupt.h"
+#include "platform/mbed_critical.h"
 
 /*****************************************************************************
 *                               PRIVATE VARIABLES                           *
@@ -524,7 +524,7 @@ void MCR20Drv_IRQ_Disable
 void
 )
 {
-    platform_enter_critical();
+    core_util_critical_section_enter();
 
     if( mPhyIrqDisableCnt == 0 )
     {
@@ -533,7 +533,7 @@ void
 
     mPhyIrqDisableCnt++;
 
-    platform_exit_critical();
+    core_util_critical_section_exit();
 }
 
 /*---------------------------------------------------------------------------
@@ -547,7 +547,7 @@ void MCR20Drv_IRQ_Enable
 void
 )
 {
-    platform_enter_critical();
+    core_util_critical_section_enter();
 
     if( mPhyIrqDisableCnt )
     {
@@ -559,7 +559,7 @@ void
         }
     }
 
-    platform_exit_critical();
+    core_util_critical_section_exit();
 }
 
 /*---------------------------------------------------------------------------

--- a/source/NanostackRfPhyMcr20a.cpp
+++ b/source/NanostackRfPhyMcr20a.cpp
@@ -1093,7 +1093,6 @@ static void rf_init_phy_mode(void)
  */
 static void PHY_InterruptHandler(void)
 {
-    /* Disable and clear transceiver(IRQ_B) interrupt */
     MCR20Drv_IRQ_Disable();
     irq_thread->signal_set(1);
 }
@@ -1106,14 +1105,13 @@ static void PHY_InterruptThread(void)
             continue;
         }
         handle_interrupt();
+        MCR20Drv_IRQ_Enable();
     }
 }
 
 static void handle_interrupt(void)
 {
     uint8_t xcvseqCopy;
-
-    //MCR20Drv_IRQ_Clear();
 
     /* Read transceiver interrupt status and control registers */
     mStatusAndControlRegs[IRQSTS1] =
@@ -1158,7 +1156,6 @@ static void handle_interrupt(void)
             MCR20Drv_DirectAccessSPIMultiByteWrite(IRQSTS1, mStatusAndControlRegs, 5);
             
             rf_ack_wait_timer_interrupt();
-            MCR20Drv_IRQ_Enable();
             return;
         }
     }
@@ -1182,7 +1179,6 @@ static void handle_interrupt(void)
             {
                 rf_receive();
             }
-            MCR20Drv_IRQ_Enable();
             return;
         }
 
@@ -1204,13 +1200,10 @@ static void handle_interrupt(void)
         default:
             break;
         }
-        
-        MCR20Drv_IRQ_Enable();
         return;
     }
     /* Other IRQ. Clear XCVR interrupt flags */
     MCR20Drv_DirectAccessSPIMultiByteWrite(IRQSTS1, mStatusAndControlRegs, 3);
-    MCR20Drv_IRQ_Enable();
 }
 
 /*


### PR DESCRIPTION
Move disabling and enabling interrupts to interrupt thread to avoid trying to obtain mutex from interrupt context.