### PR TITLE
Flag component with DEVICE_INTERRUPTIN

### DIFF
--- a/source/NanostackRfPhyMcr20a.cpp
+++ b/source/NanostackRfPhyMcr20a.cpp
@@ -15,7 +15,7 @@
  */
 #include "NanostackRfPhyMcr20a.h"
 
-#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI && defined(MBED_CONF_RTOS_PRESENT)
+#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI && DEVICE_INTERRUPTIN && defined(MBED_CONF_RTOS_PRESENT)
 
 #include "ns_types.h"
 #include "platform/arm_hal_interrupt.h"


### PR DESCRIPTION
Allow Mbed OS compilation without having INTERRUPTIN.