### PR TITLE
Fix flagging error from KW24D removal

### DIFF
--- a/source/MCR20Drv.c
+++ b/source/MCR20Drv.c
@@ -115,6 +115,7 @@ void MCR20Drv_Init
     xcvr_spi_configure_speed(gXcvrSpiInstance_c, 8000000);
 
     gXcvrDeassertCS_d();
+    MCR20Drv_RST_B_Deassert();
     RF_IRQ_Init();
     RF_IRQ_Disable();
     mPhyIrqDisableCnt = 1;

--- a/source/NanostackRfPhyMcr20a.cpp
+++ b/source/NanostackRfPhyMcr20a.cpp
@@ -62,7 +62,6 @@ extern "C" {
 
 #define gXcvrRunState_d       gXcvrPwrAutodoze_c
 #define gXcvrLowPowerState_d  gXcvrPwrHibernate_c
-#define gXcvrLowPowerState_d  gXcvrPwrAutodoze_c
 
 namespace {
 


### PR DESCRIPTION
-Do not define gXcvrLowPowerState_d twice.
-Add function call MCR20Drv_RST_B_Deassert() back